### PR TITLE
Update jruby path

### DIFF
--- a/examples/01_simple_sketch.rb
+++ b/examples/01_simple_sketch.rb
@@ -5,8 +5,11 @@ class Sketch < Processing::SketchBase
   LINE_RADIUS = 8
   LINE_SPEED = 3
 
-  def setup
+  def settings
     size(480, 240)
+  end
+  
+  def setup
     background(96)
     no_stroke
 

--- a/examples/02_input_handling.rb
+++ b/examples/02_input_handling.rb
@@ -6,8 +6,11 @@ class Sketch < Processing::SketchBase
   MIN_RADIUS, MAX_RADIUS = 40, 80
   MIN_ALPHA, MAX_ALPHA = 64, 255
 
-  def setup
+  def settings
     size(600, 400)
+  end
+
+  def setup
     background(32, 96, 160)
     fill(255)
     stroke_weight(4)

--- a/examples/03_multi_file.rb
+++ b/examples/03_multi_file.rb
@@ -5,9 +5,12 @@ require_relative 'modules/moving_box'
 # An example of splitting the sketch into multiple files
 class Sketch < Processing::SketchBase
   CUBE_NUM = 200
+  
+  def settings
+    size(640, 360, OPENGL)
+  end
 
   def setup
-    size(640, 360, OPENGL)
     background(0)
     no_stroke
 

--- a/examples/04_builtin_library.rb
+++ b/examples/04_builtin_library.rb
@@ -11,8 +11,11 @@ class Sketch < Processing::SketchBase
   MOVIE1 = Processing.sketch_path('data/cat.mov')
   MOVIE2 = Processing.sketch_path('data/dog.mov')
 
-  def setup
+  def settings
     size(800, 400, OPENGL)
+  end
+  
+  def setup
     no_stroke
 
     @mov1 = Video::Movie.new(self, MOVIE1)

--- a/examples/05_external_library.rb
+++ b/examples/05_external_library.rb
@@ -10,9 +10,11 @@ BALL_COLORS = [[255, 0, 0], [255, 255, 0], [64, 64, 255]]
 class Sketch < Processing::SketchBase
   attr_reader :handy
 
-  def setup
+  def settings
     size(400, 400)
-
+  end
+  
+  def setup
     @handy = Handy::HandyRenderer.new(self)
 
     @balls = []

--- a/lib/sketch_runner/config.rb
+++ b/lib/sketch_runner/config.rb
@@ -31,11 +31,11 @@ module SketchRunner
   end
 
   PROCESSING_URL = {
-    MACOSX: 'http://download.processing.org/processing-2.2.1-macosx.zip',
-    WIN32: 'http://download.processing.org/processing-2.2.1-windows32.zip',
-    WIN64: 'http://download.processing.org/processing-2.2.1-windows64.zip',
-    LINUX32: 'http://download.processing.org/processing-2.2.1-linux32.tgz',
-    LINUX64: 'http://download.processing.org/processing-2.2.1-linux64.tgz'
+    MACOSX: 'http://download.processing.org/processing-3.3.7-macosx.zip',
+    WIN32: 'http://download.processing.org/processing-3.3.7-windows32.zip',
+    WIN64: 'http://download.processing.org/processing-3.3.7-windows64.zip',
+    LINUX32: 'http://download.processing.org/processing-3.3.7-linux32.tgz',
+    LINUX64: 'http://download.processing.org/processing-3.3.7-linux64.tgz'
   }[PLATFORM]
 
   if PLATFORM == :MACOSX

--- a/lib/sketch_runner/config.rb
+++ b/lib/sketch_runner/config.rb
@@ -9,7 +9,7 @@ module SketchRunner
   APPDATA_ROOT = File.expand_path('~/.processing.rb')
   APPDATA_CHECK_FILE = File.join(APPDATA_ROOT, '.complete')
 
-  JRUBY_URL = 'https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre1/jruby-complete-9.0.0.0.pre1.jar'
+  JRUBY_URL = 'https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-complete-9.1.13.0.jar'
   JRUBY_FILE = File.join(APPDATA_ROOT, 'jruby/jruby.jar')
 
   if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
The old jruby path is currently non-existent, which is causing the sketch runner to fail. Updated to a valid path of jruby jar file.